### PR TITLE
fixed bug where CompCCAT would fail if exp.m is of class dgeMatrix

### DIFF
--- a/R/CompCCAT.R
+++ b/R/CompCCAT.R
@@ -69,8 +69,10 @@ CompCCAT <- function(exp.m, ppiA.m){
 
     if(classMATRIX=="matrix"){ ## ordinary matrix
       ccat.v <- as.vector(cor(exp.m[match(commonEID.v,rownames(exp.m)),],k.v));
-    }
-    else if (classMATRIX=="dgCMatrix"){
+    } else if (classMATRIX=="dgeMatrix"){ # ordinary dense matrix in S4 Matrix representation. 
+      exp.m <- as.matrix(exp.m) # dense S4 matrix representation to base matrix presentation
+      ccat.v <- as.vector(cor(exp.m[match(commonEID.v,rownames(exp.m)),],k.v))
+    } else if (classMATRIX=="dgCMatrix"){
       ccat.v <- as.vector(corSparse(exp.m[match(commonEID.v,rownames(exp.m)),],Matrix(matrix(k.v,ncol=1))));
     }
     


### PR DESCRIPTION
As mentioned in issue #5 , `CompCCAT` throws an error if the class of `exp.m` is `dgeMatrix`. 

I assume users might run into this issue, if they log transform their data with `scater::logNormCounts(sce_tx22)` and add the argument `pseudo.count = 1.1` to avoid 0 values as is mentioned in the [vignette](https://htmlpreview.github.io/?https://github.com/aet21/SCENT/blob/master/vignettes/SCENT.html). Its easy to miss that you are using `lscChu0.m` when [estimating the differentiation potency](https://htmlpreview.github.io/?https://github.com/aet21/SCENT/blob/master/vignettes/SCENT.html#differentiation-potency-estimation-using-ccat).
My fix simply transform the `dgeMatrix` to a base R `matrix` and then everything works as intended.